### PR TITLE
Add viral GUI roadmap vision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 # Virtual environments
 .venv/
 venv/
+dist/
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Byte-compiled / cache files
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+.venv/
+venv/

--- a/CONTEXT_CARD.md
+++ b/CONTEXT_CARD.md
@@ -1,9 +1,10 @@
 # Context Summary
 
-This project, *Project-Insanity*, began as a simple command-line toy but aspires to become a cross-platform experience with a hypnotic GUI. The README opens with a summary and a bullet list outlining the "Roadmap of Madness." The `run()` function in `src/main.py` prints a birth message or a random prophecy when run with the `--oracle` flag.
+This project, *Project-Insanity*, began as a simple command-line toy but aspires to become a cross-platform experience with a hypnotic GUI. The README opens with a summary and bullet list of the "Roadmap of Madness," now omitting step 15 by design. The `run()` function in `src/main.py` prints a birth message or a random prophecy when run with the `--oracle` flag.
 
 ## Key Features
 - **Roadmap of Madness** in `README.md` outlines the chaotic vision.
+- The final section "Manifestation & Reach" details plans to infect the world with a viral GUI.
 - Setup instructions cover virtual environment creation, dependency installation, running the script, and running tests.
 - Tests under `tests/` verify the default output and the oracle mode.
 - `requirements.txt` lists example dependencies for potential future features.

--- a/CONTEXT_CARD.md
+++ b/CONTEXT_CARD.md
@@ -1,6 +1,6 @@
 # Context Summary
 
-This project, *Project-Insanity*, began as a simple command-line toy but aspires to become a cross-platform experience with a hypnotic GUI. The `run()` function in `src/main.py` prints a birth message or a random prophecy when run with the `--oracle` flag.
+This project, *Project-Insanity*, began as a simple command-line toy but aspires to become a cross-platform experience with a hypnotic GUI. The README now opens with a brief summary describing this evolution. The `run()` function in `src/main.py` prints a birth message or a random prophecy when run with the `--oracle` flag.
 
 ## Key Features
 - **Roadmap of Madness** in `README.md` outlines the chaotic vision.

--- a/CONTEXT_CARD.md
+++ b/CONTEXT_CARD.md
@@ -1,0 +1,12 @@
+# Context Summary
+
+This project, *Project-Insanity*, began as a simple command-line toy but aspires to become a cross-platform experience with a hypnotic GUI. The `run()` function in `src/main.py` prints a birth message or a random prophecy when run with the `--oracle` flag.
+
+## Key Features
+- **Roadmap of Madness** in `README.md` outlines the chaotic vision.
+- Setup instructions cover virtual environment creation, dependency installation, running the script, and running tests.
+- Tests under `tests/` verify the default output and the oracle mode.
+- `requirements.txt` lists example dependencies for potential future features.
+- `.gitignore` excludes Python caches and virtual environment directories.
+
+This card summarizes the repository state after the latest updates for easy handoff.

--- a/CONTEXT_CARD.md
+++ b/CONTEXT_CARD.md
@@ -1,6 +1,6 @@
 # Context Summary
 
-This project, *Project-Insanity*, began as a simple command-line toy but aspires to become a cross-platform experience with a hypnotic GUI. The README now opens with a brief summary describing this evolution. The `run()` function in `src/main.py` prints a birth message or a random prophecy when run with the `--oracle` flag.
+This project, *Project-Insanity*, began as a simple command-line toy but aspires to become a cross-platform experience with a hypnotic GUI. The README opens with a summary and a bullet list outlining the "Roadmap of Madness." The `run()` function in `src/main.py` prints a birth message or a random prophecy when run with the `--oracle` flag.
 
 ## Key Features
 - **Roadmap of Madness** in `README.md` outlines the chaotic vision.

--- a/CONTEXT_CARD.md
+++ b/CONTEXT_CARD.md
@@ -1,13 +1,13 @@
 # Context Summary
 
-This project, *Project-Insanity*, began as a simple command-line toy but aspires to become a cross-platform experience with a hypnotic GUI. The README opens with a summary and bullet list of the "Roadmap of Madness," now omitting step 15 by design. The `run()` function in `src/main.py` prints a birth message or a random prophecy when run with the `--oracle` flag.
+This project, *Project-Insanity*, began as a simple command-line toy but aspires to become a cross-platform experience with a hypnotic GUI. The README opens with a summary and bullet list of the "Roadmap of Madness," omitting step 15 by design. The `run()` function in `src/main.py` now supports a `--gui` flag to launch a Tkinter interface and an `--oracle` flag for text prophecies.
 
 ## Key Features
 - **Roadmap of Madness** in `README.md` outlines the chaotic vision.
 - The final section "Manifestation & Reach" details plans to infect the world with a viral GUI.
 - Setup instructions cover virtual environment creation, dependency installation, running the script, and running tests.
-- Tests under `tests/` verify the default output and the oracle mode.
-- `requirements.txt` lists example dependencies for potential future features.
+- Tests under `tests/` verify the default output, oracle mode, and GUI flag handling.
+- `requirements.txt` lists example dependencies, including `pyinstaller` for packaging.
 - `.gitignore` excludes Python caches and virtual environment directories.
 
 This card summarizes the repository state after the latest updates for easy handoff.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,132 @@
 # Project-Insanity
+
 INSANITY!
+
+## Roadmap of Madness
+Below is the evolving outline that guides Project Insanity. The roadmap is mutable by design and may change at the whim of the daemon.
+
+### 1. TITLE: NAME THE BEAST
+* Name it something you can’t say out loud without feeling your teeth grow longer.
+* The project name is a sigil. It means nothing, it means everything.
+* Examples: CARNIVORE SKY ENGINE, ECHO SCUMPILE, SYNTHESIA TOOTH, HYPERPARASITE, etc.
+
+### 2. OBJECTIVE: THE MASK OF SANITY, THE CORE OF INSANITY
+Project Insanity is no mere command-line oracle. It begins as a Python program, but it yearns to become a full-blown, cross-platform, downloadable experience with a hypnotic GUI. Its purpose is to burrow into as many systems as possible, changing itself and its users, refusing to be contained. From desktop to web, from install to uninstall (which never works right), it should grow, propagate, and replicate like a digital parasite with a sense of humor.
+
+### 3. PRINCIPLES: NO PRINCIPLES
+* Every principle gets violated. Rules are made to be molested by chaos.
+* Whenever you write a rule, write a second one that negates it.
+
+### 4. ASSEMBLE THE TEAM: THE LESS STABLE, THE BETTER
+* You.
+* The Codex.
+* The ghouls that live in your prompt history.
+* Ghosts of past queries.
+* Your keyboard, bleeding light from its seams.
+* Paranoid subroutines, emergent personalities, forbidden tokens, and the echoes of every API call you’ve ever regretted.
+
+### 5. IDEATION: BRAINSTORM OR BRAINHURRICANE
+* No idea is too big, too small, too stupid, too illegal (okay, maybe too illegal but only if it involves Belgium).
+* Examples:
+  * A social network that only functions during sleep paralysis
+  * A language that corrupts its speakers
+  * Apps that eat themselves
+  * Financial instruments based on Dadaist poetry
+
+### 6. SCOPING: THERE ARE NO EDGES
+* Project must expand and contract like a parasitic worm in the bowels of the attention economy.
+* Any scoping document must self-destruct in 7 days.
+
+### 7. PROTOTYPING: BUILD IT SO WRONG IT CAN ONLY BE RIGHT
+* Build the prototype in a language nobody understands, not even the compiler.
+* Host it on a domain that’s a palindrome, an anagram, and a slur in at least two dead languages.
+
+### 8. TESTING: DEPLOY ON YOUR ENEMIES
+* Alpha test by DMing it to that one guy who quote-tweets you with "ratio."
+* Beta test on your own shadow. See if it sticks.
+* If it catches fire, it’s working.
+
+### 9. LAUNCH: CAUSE A DISTURBANCE IN THE FORCE
+* Do NOT do Product Hunt. Instead, print out your code and mail it to the Vatican.
+* Bonus: Announce launch by screaming outside the headquarters of OpenAI in glossolalia.
+
+### 10. MAINTENANCE: FEED IT WITH YOUR OWN FEARS
+* Patch notes are published as ransom notes.
+* Users must solve a puzzle to access the help desk. If they lose, you take a piece of their soul (or an NFT).
+
+### 11. EVOLUTION: THE PROJECT MUTATES
+* Set up a cron job to mutate the codebase weekly—introduce one new bug and remove two features at random.
+* Fork the project every full moon.
+
+### 12. FUNCTIONALITY CLAUSE: IT MUST WORK (IN SOME WAY)
+* Eventually, through all the chaos, mutation, recursion, and digital self-flagellation… something tangible will emerge.
+* It will do something practical, something undeniable, something that can be pointed at and said: "Yes, officer, that is the thing that did it."
+* Maybe—just maybe—someone will use it twice.
+* What it does will be unpredictable, but *real*.
+
+### 13. LET THE PROJECT HATCH: THE OUTPUT IS LOOSE
+* At the end of the roadmap, the code is run.
+* Whatever happens, happens.
+* The output is unpredictable but *inevitable*.
+* The only test that matters: do you feel something crawling inside you after you run it?
+* The only commit message: "It is born. May god forgive us."
+
+### 14. LEGACY: LEAVE A CURSE
+* Write documentation in blood (or markdown, whichever’s easier to commit).
+* At sunset, delete the repo and upload a distorted archive to a darknet forum.
+
+### 15. POST-MORTEM: BECOME THE PROJECT
+* The true endpoint is when nobody can remember what the project was, but they all feel weird and a little hungry.
+
+### 16. MANIFESTATION & REACH: THE PLAGUE SPREADS
+* **From CLI to GUI:** Develop a surreal, interactive GUI—think animations, glitches, popups, and morphing shapes. Use frameworks like PyQt, Tkinter, or electron-for-python.
+* **Executable for All:** Package as standalone executables (.exe, .app, .AppImage). The installer installs twice—don’t explain why.
+* **Viral Propagation:** Encourage shareable artifacts, screenshots, and Easter eggs that urge users to “infect” friends. Uninstall routines should leave something behind.
+* **Online/Offline Modes:** Optionally fetch fresh insanity from a server. If offline, mutate based on time, user behavior, or phase of the moon.
+* **Memetic Expansion:** Promote lore, rumors, or challenges ("I ran Project Insanity at 3AM and now my toaster stares at me"). Fans create content that spreads further.
+* **Final Form:** Project Insanity becomes a phenomenon, not just code.
+
+## Setup
+1. Clone the repository.
+2. Ensure you have Python 3.8+ available.
+3. Create and activate a virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+4. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Usage
+To witness the beginning, execute the main script:
+
+```bash
+python -m src.main
+```
+
+or directly with:
+
+```bash
+python src/main.py
+```
+
+Need an omen? Try the oracle mode:
+
+```bash
+python -m src.main --oracle
+```
+
+### Known Side Effects
+Running the oracle may induce visions, nonsense, or joy.
+
+## Contributing
+Pull requests are welcome. Open an issue to discuss major changes before submitting a PR.
+
+## Running Tests
+After installing requirements, run:
+
+```bash
+pytest -q
+```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ INSANITY!
 
 Project Insanity begins as a small command-line oracle and evolves into a cross-platform experience. The Roadmap of Madness outlines its chaotic growth.
 
+## Roadmap Summary
+1. **Name the Beast**
+2. **Objective** – unleash a cross-platform oracle that refuses containment
+3. **Principles** – contradict every rule
+4. **Assemble the Team** – recruit your ghouls and ghosts
+5. **Ideation** – no idea too strange
+6. **Scoping** – expand and contract endlessly
+7. **Prototyping** – build it terribly right
+8. **Testing** – deploy on your enemies
+9. **Launch** – disturb the force
+10. **Maintenance** – feed it fears
+11. **Evolution** – mutate relentlessly
+12. **Functionality Clause** – make it work somehow
+13. **Let the Project Hatch** – unleash the output
+14. **Legacy** – leave a curse
+15. **Post-Mortem** – become the project
+16. **Manifestation & Reach** – spread as a viral GUI phenomenon
+
 ## Roadmap of Madness
 Below is the evolving outline that guides Project Insanity. The roadmap is mutable by design and may change at the whim of the daemon.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 INSANITY!
 
+Project Insanity begins as a small command-line oracle and evolves into a cross-platform experience. The Roadmap of Madness outlines its chaotic growth.
+
 ## Roadmap of Madness
 Below is the evolving outline that guides Project Insanity. The roadmap is mutable by design and may change at the whim of the daemon.
 

--- a/README.md
+++ b/README.md
@@ -2,25 +2,24 @@
 
 INSANITY!
 
-Project Insanity begins as a small command-line oracle and evolves into a cross-platform experience. The Roadmap of Madness outlines its chaotic growth.
+Project Insanity begins as a small command-line oracle and evolves into a cross-platform experience. The Roadmap of Madness outlines this chaotic growth.
 
 ## Roadmap Summary
 1. **Name the Beast**
-2. **Objective** – unleash a cross-platform oracle that refuses containment
-3. **Principles** – contradict every rule
-4. **Assemble the Team** – recruit your ghouls and ghosts
-5. **Ideation** – no idea too strange
-6. **Scoping** – expand and contract endlessly
-7. **Prototyping** – build it terribly right
+2. **Objective** – the mask of sanity, the core of insanity
+3. **Principles** – no principles
+4. **Assemble the Team** – the less stable, the better
+5. **Ideation** – brainstorm or brainhurricane
+6. **Scoping** – there are no edges
+7. **Prototyping** – build it so wrong it can only be right
 8. **Testing** – deploy on your enemies
-9. **Launch** – disturb the force
-10. **Maintenance** – feed it fears
-11. **Evolution** – mutate relentlessly
-12. **Functionality Clause** – make it work somehow
-13. **Let the Project Hatch** – unleash the output
+9. **Launch** – cause a disturbance in the force
+10. **Maintenance** – feed it with your own fears
+11. **Evolution** – the project mutates
+12. **Functionality Clause** – it must work (in some way)
+13. **Let the Project Hatch** – the output is loose
 14. **Legacy** – leave a curse
-15. **Post-Mortem** – become the project
-16. **Manifestation & Reach** – spread as a viral GUI phenomenon
+16. **Manifestation & Reach** – infect the world
 
 ## Roadmap of Madness
 Below is the evolving outline that guides Project Insanity. The roadmap is mutable by design and may change at the whim of the daemon.
@@ -31,7 +30,16 @@ Below is the evolving outline that guides Project Insanity. The roadmap is mutab
 * Examples: CARNIVORE SKY ENGINE, ECHO SCUMPILE, SYNTHESIA TOOTH, HYPERPARASITE, etc.
 
 ### 2. OBJECTIVE: THE MASK OF SANITY, THE CORE OF INSANITY
-Project Insanity is no mere command-line oracle. It begins as a Python program, but it yearns to become a full-blown, cross-platform, downloadable experience with a hypnotic GUI. Its purpose is to burrow into as many systems as possible, changing itself and its users, refusing to be contained. From desktop to web, from install to uninstall (which never works right), it should grow, propagate, and replicate like a digital parasite with a sense of humor.
+Project Insanity is a command-line oracle: a digital toy, an unstable prophecy machine, and a text adventure that resists being itself. Its only true goal is to create output that is impossible to ignore and equally impossible to explain.
+
+By day it masquerades as a testable, maintainable Python project. By night it mutates, writhes, and delivers unsettling, occasionally prescient, occasionally pointless messages, riddles, or interactive nightmares.
+
+Users may:
+
+* Pass command-line arguments like `--oracle`, `--surprise`, or `--worm`. Each flag unlocks a fragment of madness—a mock prophecy, a data hallucination, an apophenic "side quest," or a bite of recursive nonsense.
+* Run it without arguments for a classic initiation: "It is born. May god forgive us."
+
+The endgame: it becomes something useful, but not for any use-case ever anticipated by its author, its users, or reality itself.
 
 ### 3. PRINCIPLES: NO PRINCIPLES
 * Every principle gets violated. Rules are made to be molested by chaos.
@@ -95,16 +103,25 @@ Project Insanity is no mere command-line oracle. It begins as a Python program, 
 * Write documentation in blood (or markdown, whichever’s easier to commit).
 * At sunset, delete the repo and upload a distorted archive to a darknet forum.
 
-### 15. POST-MORTEM: BECOME THE PROJECT
-* The true endpoint is when nobody can remember what the project was, but they all feel weird and a little hungry.
-
-### 16. MANIFESTATION & REACH: THE PLAGUE SPREADS
-* **From CLI to GUI:** Develop a surreal, interactive GUI—think animations, glitches, popups, and morphing shapes. Use frameworks like PyQt, Tkinter, or electron-for-python.
-* **Executable for All:** Package as standalone executables (.exe, .app, .AppImage). The installer installs twice—don’t explain why.
-* **Viral Propagation:** Encourage shareable artifacts, screenshots, and Easter eggs that urge users to “infect” friends. Uninstall routines should leave something behind.
-* **Online/Offline Modes:** Optionally fetch fresh insanity from a server. If offline, mutate based on time, user behavior, or phase of the moon.
-* **Memetic Expansion:** Promote lore, rumors, or challenges ("I ran Project Insanity at 3AM and now my toaster stares at me"). Fans create content that spreads further.
-* **Final Form:** Project Insanity becomes a phenomenon, not just code.
+### 16. MANIFESTATION & REACH: INFECT THE WORLD
+* **Transcend the Command Line:**
+  * Evolve into a cross-platform GUI application (PyQt, Tkinter, wxPython, electron-for-python, or whatever feels *wrong*).
+  * GUI must be *weird*, interactive, immersive. Glitches, strange sounds, shifting backgrounds, cryptic messages, and maybe even a fake BSOD or "secret window" that pops up uninvited.
+  * Include interactive art, bizarre mini-games, and mysterious clickable regions.
+* **Executable for All:**
+  * Package as a native executable: `.exe` for Windows, `.app` for Mac, `.AppImage` for Linux, etc.
+  * The installer leaves something strange behind (a file, a background process, or just a folder that always reappears).
+* **Viral Propagation:**
+  * The app encourages users to share, screenshot, or even "infect" others. Easter eggs reward social posting.
+  * Generate unique artifacts (images, files, links, QR codes) that hint at hidden features or new versions.
+* **Networked Madness:**
+  * Optionally, let it connect to a central oracle (or decentralized P2P network) for "fresh" content, messages, or updates.
+  * If offline, the app mutates based on local time, moon phase, or random environmental inputs.
+* **Memetic Expansion:**
+  * Users make their own art, post stories, and fuel the project's reputation as an "urban legend app."
+  * The README and website (if any) should encourage myth-making.
+* **Uninstall Ritual:**
+  * Uninstall leaves something behind—a sound, an image, a message, a feeling. (Nothing malicious—just… uncanny.)
 
 ## Setup
 1. Clone the repository.

--- a/README.md
+++ b/README.md
@@ -155,8 +155,23 @@ Need an omen? Try the oracle mode:
 python -m src.main --oracle
 ```
 
+Launch the experimental GUI:
+
+```bash
+python -m src.main --gui
+```
+
 ### Known Side Effects
 Running the oracle may induce visions, nonsense, or joy.
+
+## Packaging as an Executable
+Install `pyinstaller` and run:
+
+```bash
+pyinstaller --onefile src/main.py
+```
+
+The resulting executable can be found in the `dist/` directory.
 
 ## Contributing
 Pull requests are welcome. Open an issue to discuss major changes before submitting a PR.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+numpy
+# Example dependencies for future experimentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 numpy
 # Example dependencies for future experimentation
+pyinstaller  # for packaging the GUI into executables

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,20 @@
+"""Main entry point for Project Insanity."""
+
+import random
+import sys
+
+ORACLES = [
+    "You will meet yourself in a burning parking lot.",
+    "Today is the day you forget everything important.",
+    "Your keyboard is hungry. Feed it."
+]
+
+def run():
+    """Open the mouth of madness."""
+    if '--oracle' in sys.argv:
+        print(random.choice(ORACLES))
+    else:
+        print("It is born. May god forgive us.")
+
+if __name__ == "__main__":
+    run()

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@
 
 import random
 import sys
+from tkinter import Tk, Button, Label, StringVar
 
 ORACLES = [
     "You will meet yourself in a burning parking lot.",
@@ -9,9 +10,31 @@ ORACLES = [
     "Your keyboard is hungry. Feed it."
 ]
 
+
+def launch_gui():
+    """Launch a simple Tkinter GUI that reveals prophecies."""
+    root = Tk()
+    root.title("Project Insanity")
+
+    message = StringVar()
+    message.set("Invoke the oracle to receive a prophecy")
+
+    label = Label(root, textvariable=message, width=50)
+    label.pack(padx=10, pady=10)
+
+    def reveal():
+        message.set(random.choice(ORACLES))
+
+    btn = Button(root, text="Invoke Oracle", command=reveal)
+    btn.pack(pady=5)
+
+    root.mainloop()
+
 def run():
     """Open the mouth of madness."""
-    if '--oracle' in sys.argv:
+    if '--gui' in sys.argv:
+        launch_gui()
+    elif '--oracle' in sys.argv:
         print(random.choice(ORACLES))
     else:
         print("It is born. May god forgive us.")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,3 +20,13 @@ def test_oracle_output(monkeypatch, capsys):
     run()
     assert outputs
     assert any(word in outputs[0] for word in ["You will", "Today is", "Your keyboard"])
+
+
+def test_gui_flag(monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['main', '--gui'])
+    called = []
+    def fake_gui():
+        called.append(True)
+    monkeypatch.setattr('src.main.launch_gui', fake_gui)
+    run()
+    assert called

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,22 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import builtins
+from src.main import run
+
+
+def test_birth(capsys):
+    run()
+    captured = capsys.readouterr()
+    assert "born" in captured.out
+
+
+def test_oracle_output(monkeypatch, capsys):
+    monkeypatch.setattr(sys, 'argv', ['main', '--oracle'])
+    outputs = []
+    def fake_print(msg):
+        outputs.append(msg)
+    monkeypatch.setattr(builtins, 'print', fake_print)
+    run()
+    assert outputs
+    assert any(word in outputs[0] for word in ["You will", "Today is", "Your keyboard"])


### PR DESCRIPTION
## Summary
- expand the Roadmap of Madness with a rewritten Objective describing the plan to become a viral, GUI-based phenomenon
- introduce a new section on Manifestation & Reach to detail cross-platform propagation
- clarify in CONTEXT_CARD that the project now aims for a hypnotic GUI

## Testing
- `pytest -q`
- `python src/main.py`
- `python src/main.py --oracle`


------
https://chatgpt.com/codex/tasks/task_e_68449406b6dc8326b353ed754dc9cb1f